### PR TITLE
Detach will wait for 'done' event

### DIFF
--- a/manchester/encoder.cpp
+++ b/manchester/encoder.cpp
@@ -127,6 +127,8 @@ void ManchesterEncoder::attach(mbed::Callback<void(uint32_t)> status_cb)
 
 void ManchesterEncoder::detach()
 {
+    // Wait for the done flag or 100 ms max 
+    event_flags.wait_all(DONE_FLAG, 100);
     bit_recv_total = 8;
     if (_sensor_event_cb) {
         _sensor_event_cb_save = _sensor_event_cb;
@@ -156,6 +158,7 @@ void ManchesterEncoder::stop()
     // Call sensor event handler
     if (_sensor_event_cb)
         _sensor_event_cb(recv_data);
+    event_flags.set(DONE_FLAG);
     _input_pin.rise(callback(this, &ManchesterEncoder::rise_handler));
 }
 

--- a/manchester/encoder.h
+++ b/manchester/encoder.h
@@ -18,6 +18,8 @@
 
 #include "mbed.h"
 
+#define DONE_FLAG (1UL << 0)
+
 struct event_msg {
     uint8_t addr;
     uint8_t inst_type;
@@ -72,6 +74,7 @@ private:
     bool _idle_state;
     Timeout t1;
     Timeout t2;
+    EventFlags event_flags;
 
     Callback<void(uint32_t)> _sensor_event_cb;
     Callback<void(uint32_t)> _sensor_event_cb_save;


### PR DESCRIPTION
Done event will be generated after all data has been read from the bus and any
attached callback has finished executing

Before detaching callback, the function will wait fot this event must be generated OR a timeout of
100 ms